### PR TITLE
removed ignore changes to make it possible to add tags after initial creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  
-## [Unreleased (1.1.1)] - 2023-10-17
+## [Unreleased]
+
+## [1.1.1] - 2023-10-17
  
 ### Added
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this module will be documented in this file.
+ 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+ 
+## [Unreleased (1.1.1)] - 2023-10-17
+ 
+### Added
+ 
+### Changed
+ 
+### Removed
+ - removed ignore_changes for tags in the windows virtual machine resource
+### Fixed
+ - you can now add tags also after initial deployment, they are not ignored anymore

--- a/main.tf
+++ b/main.tf
@@ -72,8 +72,7 @@ resource "azurerm_windows_virtual_machine" "this" {
   lifecycle {
     prevent_destroy = true
     ignore_changes = [
-      identity,
-      tags
+      identity
     ]
   }
 }


### PR DESCRIPTION
removed ignore changes to make it possible to add tags after initial creation

# Description
removed ignore changes to make it possible to add tags after initial creation
<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `1.1.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `1.1.1`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Apply of all examples was successful


# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
