### PR TITLE
fix: fix validation for vmconfig.zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [5.0.2] - 2025-02-25
+
+Bugfix in type validation of `virtual_machine_config.zone`.
+
 ## [5.0.1] - 2024-10-29
 
 Bugfix to make update management work again by default.

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "virtual_machine_config" {
     error_message = "os_disk_write_accelerator_enabled, can only be activated on Premium disks and caching deactivated."
   }
   validation {
-    condition     = var.virtual_machine_config.zone == null || var.virtual_machine_config.zone == 1 || var.virtual_machine_config.zone == 2 || var.virtual_machine_config.zone == 3
+    condition     = var.virtual_machine_config.zone == null || var.virtual_machine_config.zone == "1" || var.virtual_machine_config.zone == "2" || var.virtual_machine_config.zone == "3"
     error_message = "Zone, can only be empty, 1, 2 or 3."
   }
   description = <<-DOC


### PR DESCRIPTION
# Description

vmconfig.zone must be a string, but validation checks for numbers D:
Let's fix that real quick!

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `5.0.1`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `5.0.2`

# How Has This Been Tested?

no test, we simply fix a type error in a variable validation

# Checklist:

- [ ] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
