### PR TITLE
fix: fix azurerm version constraint for `accelerated_networking_enabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [5.0.3] - 2025-02-26
+
+Fixes too low version constraint due to parameter `accelerated_networking_enabled`.
+
 ## [5.0.2] - 2025-02-25
 
 Bugfix in type validation of `virtual_machine_config.zone`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ resource "azurerm_subnet" "this" {
 ```hcl
 provider "azurerm" {
   features {}
+
+  skip_provider_registration = true
 }
 
 module "virtual_machine" {
@@ -68,7 +70,7 @@ module "virtual_machine" {
   nic_config = {
     private_ip                    = "10.0.0.16"
     dns_servers                   = ["10.0.0.10", "10.0.0.11"]
-    enable_accelerated_networking = true
+    enable_accelerated_networking = false
     nsg                           = azurerm_network_security_group.this
   }
   virtual_machine_config = {
@@ -210,7 +212,7 @@ resource "azurerm_network_security_group" "this" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.7.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.108.0 |
 
 ## Inputs
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -1,5 +1,7 @@
 provider "azurerm" {
   features {}
+
+  skip_provider_registration = true
 }
 
 module "virtual_machine" {
@@ -11,7 +13,7 @@ module "virtual_machine" {
   nic_config = {
     private_ip                    = "10.0.0.16"
     dns_servers                   = ["10.0.0.10", "10.0.0.11"]
-    enable_accelerated_networking = true
+    enable_accelerated_networking = false
     nsg                           = azurerm_network_security_group.this
   }
   virtual_machine_config = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,8 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.7.0"
+      version = "~> 3.108.0"
     }
   }
 }
+


### PR DESCRIPTION
# Description

For network interfaces, the parameter `accelerated_networking_enabled` is only available for version 3.108.0 and beyond.
Version 3.107.0 and before use the parameter `enable_accelerated_networking` instead. Since we use the first one, we should also properly set our azurerm version constraint to make sure every user of this module uses the correct version.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `5.0.2`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `5.0.3`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Test of advanced example in VSE subscription was successful

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
