### PR TITLE
fix: fix version constraint to allow minor upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [5.0.4] - 2025-02-26
+
+Bugfix to allow azurerm to use minor version upgrades.
+
 ## [5.0.3] - 2025-02-26
 
 Fixes too low version constraint due to parameter `accelerated_networking_enabled`.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ resource "azurerm_network_security_group" "this" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.108.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.108 |
 
 ## Inputs
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.108.0"
+      version = "~> 3.108"
     }
   }
 }


### PR DESCRIPTION
# Description

The latest version constraint only allows PATCH upgrades, no MINOR upgrades.
This PR fixes that.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `5.0.3`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `5.0.4`

# How Has This Been Tested?

Not at all

# Checklist:

- [ ] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
